### PR TITLE
fix: configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ You can clone it anywhere, just run `make` inside the cloned directory to build
 This does require a postgres database to be setup and reachable. It will attempt to create and migrate the database upon starting.
 
 ## Configuration
-The configuration is designed to be specified with environment variables in all caps with underscores instead of periods. 
+The configuration is designed to be specified either with environment variables or configuration files.
+Environment variables are all caps with underscores instead of periods.
 ```
 Example:
 LOGGER_LEVEL=debug
+```
+```
+Example config.yaml:
+database:
+  host: db-host
 ```
 
 ### Options:


### PR DESCRIPTION
This PR fixes configuration file support.

cobra parses the flagSet when a command is Executed. As a consequence, we need to load config files during command initialization. We can leverage [cobra.OnInitialize](https://pkg.go.dev/github.com/spf13/cobra#OnInitialize) to accomplish this cleanly.